### PR TITLE
allow bot on zoom subdomains for enterprise accounts

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -8,7 +8,7 @@ chrome.runtime.onInstalled.addListener(function() {
   chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
     chrome.declarativeContent.onPageChanged.addRules([{
       conditions: [new chrome.declarativeContent.PageStateMatcher({
-        pageUrl: {hostEquals: 'zoom.us'},
+        pageUrl: {hostSuffix: 'zoom.us'},
       })],
        actions: [new chrome.declarativeContent.ShowPageAction()]
     }]);


### PR DESCRIPTION
Allow extension on zoom subdomains e.g. enterprise.zoom.us

Probably not the best way to do it because it also matches somethingzoom.us but here's a start at least.